### PR TITLE
install: bower as part of setup.py

### DIFF
--- a/beard_server/version.py
+++ b/beard_server/version.py
@@ -31,4 +31,4 @@ and parsed by ``setup.py``.
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@
 
 
 [aliases]
+install = build_bower install
 test=pytest
 
 [build_sphinx]

--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,12 @@ setup_requires = [
 install_requires = [
     'beard>=0.2',
     'celery>=3.1.23',
-    'flower>=0.9.1',
     'Flask-BabelEx>=0.9.2',
     'gunicorn>=19.6.0',
     'honcho>=0.7.1',
     'msgpack-python>=0.4.7',
     'numpy>=1.11.0',
+    'setuptools-bower>=0.2.0',
     'scipy>=0.17.1',
 ]
 


### PR DESCRIPTION
- Running python setup.py install adds bower install command.
- Resolves #19.

Signed-off-by: Grzegorz Jacenków grzegorz.jacenkow@cern.ch
