### PR TITLE
install: setup.py bdist_wheel fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@
 
 
 [aliases]
+bdist_wheel = build_bower bdist_wheel
 install = build_bower install
 test=pytest
 


### PR DESCRIPTION
- Fixes bower install via bdist_wheel command.

Signed-off-by: Grzegorz Jacenków grzegorz.jacenkow@cern.ch
