### PR TITLE
travis: add clint as dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 - '2.7'
 before_install:
 - travis_retry pip install --upgrade pip setuptools py
-- travis_retry pip install twine wheel coveralls
+- travis_retry pip install clint twine wheel coveralls
 install:
 - travis_retry pip install -e .[all]
 script:


### PR DESCRIPTION
- Adds clint as part of before_install.

Signed-off-by: Grzegorz Jacenków grzegorz.jacenkow@cern.ch
